### PR TITLE
Improve Redis warmup pipeline

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -160,8 +160,8 @@ func main() {
 	disconnectHandler := handlers.NewDisconnectHandler(disconnectUsecase)
 	configHandler := handlers.NewConfigHandler(configUsecase)
 
-	// ✅ ENHANCED: Initialize cache handler
-	cacheHandler := handlers.NewCacheHandler(redisClient)
+	// ✅ ENHANCED: Initialize cache handler with repositories
+	cacheHandler := handlers.NewCacheHandler(redisClient, userRepo, groupRepo, configRepo)
 
 	// Initialize router with all handlers
 	router := httpRouter.NewRouterUpdated(
@@ -187,6 +187,20 @@ func main() {
 			logger.Log.Info("Starting cache warmup in background")
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
+
+			// Warm up user cache
+			if cachedUserRepo, ok := userRepo.(*xmlrpcRepositories.CachedUserRepository); ok {
+				if err := cachedUserRepo.WarmupCache(ctx); err != nil {
+					logger.Log.WithError(err).Warn("Failed to warm up user cache")
+				}
+			}
+
+			// Warm up group cache
+			if cachedGroupRepo, ok := groupRepo.(*xmlrpcRepositories.CachedGroupRepository); ok {
+				if err := cachedGroupRepo.WarmupCache(ctx); err != nil {
+					logger.Log.WithError(err).Warn("Failed to warm up group cache")
+				}
+			}
 
 			// Warm up config cache (most important)
 			if cachedConfigRepo, ok := configRepo.(*xmlrpcRepositories.CachedConfigRepository); ok {

--- a/config/config-development.yml
+++ b/config/config-development.yml
@@ -112,3 +112,4 @@ features:
   
   # Enable cache statistics endpoint
   enableCacheStats: true
+

--- a/internal/infrastructure/repositories/cached_group_repository.go
+++ b/internal/infrastructure/repositories/cached_group_repository.go
@@ -30,18 +30,14 @@ func (r *CachedGroupRepository) Create(ctx context.Context, group *entities.Grou
 		return err
 	}
 
+	// 🔥 Invalidate caches synchronously before caching new group
+	if err := r.invalidateGroupCaches(ctx, group.GroupName); err != nil {
+		logger.Log.WithField("groupName", group.GroupName).WithError(err).Warn("Failed to invalidate cache after group creation")
+	}
+
 	// 🔥 Write-through caching: Cache the new group immediately
 	groupKey := r.getGroupKey(group.GroupName)
 	r.cache.SetAsync(ctx, groupKey, group, redis.GroupTTL)
-
-	// 🔥 Async cache invalidation to avoid blocking
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := r.invalidateGroupCaches(ctx, group.GroupName); err != nil {
-			logger.Log.WithField("groupName", group.GroupName).WithError(err).Warn("Failed to invalidate cache after group creation")
-		}
-	}()
 
 	logger.Log.WithField("groupName", group.GroupName).Debug("Group created, cache updated")
 	return nil
@@ -79,18 +75,14 @@ func (r *CachedGroupRepository) Update(ctx context.Context, group *entities.Grou
 		return err
 	}
 
-	// 🔥 Write-through caching: Update cache immediately with fresh data
+	// 🔥 Invalidate caches synchronously before caching the updated group
+	if err := r.invalidateGroupCaches(ctx, group.GroupName); err != nil {
+		logger.Log.WithField("groupName", group.GroupName).WithError(err).Warn("Failed to invalidate cache after group update")
+	}
+
+	// 🔥 Write-through caching: store the fresh data
 	groupKey := r.getGroupKey(group.GroupName)
 	r.cache.SetAsync(ctx, groupKey, group, redis.GroupTTL)
-
-	// 🔥 Async cache invalidation for related caches
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := r.invalidateGroupCaches(ctx, group.GroupName); err != nil {
-			logger.Log.WithField("groupName", group.GroupName).WithError(err).Warn("Failed to invalidate cache after group update")
-		}
-	}()
 
 	logger.Log.WithField("groupName", group.GroupName).Debug("Group updated, cache refreshed")
 	return nil
@@ -106,14 +98,10 @@ func (r *CachedGroupRepository) Delete(ctx context.Context, groupName string) er
 	groupKey := r.getGroupKey(groupName)
 	r.cache.DelAsync(ctx, groupKey)
 
-	// 🔥 Async invalidation for related caches
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := r.invalidateGroupCaches(ctx, groupName); err != nil {
-			logger.Log.WithField("groupName", groupName).WithError(err).Warn("Failed to invalidate cache after group deletion")
-		}
-	}()
+	// 🔥 Invalidate related caches synchronously
+	if err := r.invalidateGroupCaches(ctx, groupName); err != nil {
+		logger.Log.WithField("groupName", groupName).WithError(err).Warn("Failed to invalidate cache after group deletion")
+	}
 
 	logger.Log.WithField("groupName", groupName).Debug("Group deleted, cache cleared")
 	return nil
@@ -214,6 +202,13 @@ func (r *CachedGroupRepository) ExistsByName(ctx context.Context, groupName stri
 		return true, nil
 	}
 
+	// Check negative cache first
+	negativeKey := fmt.Sprintf("group_not_exists:%s", groupName)
+	var notExists bool
+	if err := r.cache.Get(ctx, negativeKey, &notExists); err == nil && notExists {
+		return false, nil
+	}
+
 	// Cache miss - check repository
 	exists, err := r.repo.ExistsByName(ctx, groupName)
 	if err != nil {
@@ -222,8 +217,9 @@ func (r *CachedGroupRepository) ExistsByName(ctx context.Context, groupName stri
 
 	// 🔥 Cache negative results briefly to prevent repeated DB queries
 	if !exists {
-		negativeKey := fmt.Sprintf("group_not_exists:%s", groupName)
-		r.cache.SetAsync(ctx, negativeKey, false, 1*time.Minute)
+		r.cache.SetAsync(ctx, negativeKey, true, 1*time.Minute)
+	} else {
+		r.cache.DelAsync(ctx, negativeKey)
 	}
 
 	return exists, nil
@@ -235,14 +231,10 @@ func (r *CachedGroupRepository) Enable(ctx context.Context, groupName string) er
 		return err
 	}
 
-	// 🔥 Async cache invalidation
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := r.invalidateGroupCaches(ctx, groupName); err != nil {
-			logger.Log.WithField("groupName", groupName).WithError(err).Warn("Failed to invalidate cache after group enable")
-		}
-	}()
+	// 🔥 Invalidate caches synchronously
+	if err := r.invalidateGroupCaches(ctx, groupName); err != nil {
+		logger.Log.WithField("groupName", groupName).WithError(err).Warn("Failed to invalidate cache after group enable")
+	}
 
 	return nil
 }
@@ -253,14 +245,10 @@ func (r *CachedGroupRepository) Disable(ctx context.Context, groupName string) e
 		return err
 	}
 
-	// 🔥 Async cache invalidation
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := r.invalidateGroupCaches(ctx, groupName); err != nil {
-			logger.Log.WithField("groupName", groupName).WithError(err).Warn("Failed to invalidate cache after group disable")
-		}
-	}()
+	// 🔥 Invalidate caches synchronously
+	if err := r.invalidateGroupCaches(ctx, groupName); err != nil {
+		logger.Log.WithField("groupName", groupName).WithError(err).Warn("Failed to invalidate cache after group disable")
+	}
 
 	return nil
 }
@@ -271,14 +259,10 @@ func (r *CachedGroupRepository) ClearAccessControl(ctx context.Context, group *e
 		return err
 	}
 
-	// 🔥 Async cache invalidation
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := r.invalidateGroupCaches(ctx, group.GroupName); err != nil {
-			logger.Log.WithField("groupName", group.GroupName).WithError(err).Warn("Failed to invalidate cache after clearing access control")
-		}
-	}()
+	// 🔥 Invalidate caches synchronously
+	if err := r.invalidateGroupCaches(ctx, group.GroupName); err != nil {
+		logger.Log.WithField("groupName", group.GroupName).WithError(err).Warn("Failed to invalidate cache after clearing access control")
+	}
 
 	return nil
 }
@@ -328,4 +312,20 @@ func (r *CachedGroupRepository) isEmptyFilter(filter *entities.GroupFilter) bool
 		filter.IsEnabled == nil &&
 		filter.Limit == 0 &&
 		filter.Offset == 0
+}
+
+// WarmupCache preloads commonly accessed groups into cache
+func (r *CachedGroupRepository) WarmupCache(ctx context.Context) error {
+	groups, err := r.repo.List(ctx, &entities.GroupFilter{Limit: 100})
+	if err != nil {
+		return err
+	}
+
+	kvs := make([]redis.KeyValue, 0, len(groups)+1)
+	kvs = append(kvs, redis.KeyValue{Key: "groups:list", Value: groups, TTL: redis.GroupTTL})
+	for _, g := range groups {
+		kvs = append(kvs, redis.KeyValue{Key: r.getGroupKey(g.GroupName), Value: g, TTL: redis.GroupTTL})
+	}
+
+	return r.cache.SetMultiple(ctx, kvs)
 }


### PR DESCRIPTION
## Summary
- add `KeyValue` struct and a `SetMultiple` helper using Redis pipeline
- preload user and group caches using the new pipeline function
- warm up user and group caches during startup
- invalidate user caches synchronously on update
- gracefully shut down Redis workers to finish queued jobs
- invalidate user and group caches synchronously before re-caching

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6852c108fc98832cbad4fe646da31b63