### PR TITLE
Add static/dynamic IP support for users

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -540,6 +540,15 @@ definitions:
         items:
           type: string
         type: array
+      ipAddress:
+        example: 10.0.0.10
+        type: string
+      ipAssignMode:
+        enum:
+        - dynamic
+        - static
+        example: dynamic
+        type: string
       password:
         example: SecurePass123!
         type: string
@@ -556,6 +565,7 @@ definitions:
     - email
     - macAddresses
     - userExpiration
+    - ipAssignMode
     - username
     type: object
   dto.DisconnectResponse:
@@ -1177,6 +1187,15 @@ definitions:
       userExpiration:
         example: 31/12/2025
         type: string
+      ipAddress:
+        example: 10.0.0.10
+        type: string
+      ipAssignMode:
+        enum:
+        - dynamic
+        - static
+        example: dynamic
+        type: string
     type: object
   dto.UserConnectionInfo:
     properties:
@@ -1401,6 +1420,12 @@ definitions:
         type: string
       groupName:
         example: TEST_GR
+        type: string
+      ipAddress:
+        example: 10.0.0.10
+        type: string
+      ipAssignMode:
+        example: dynamic
         type: string
       isEnabled:
         description: 'NEW: Computed fields for enhanced filtering'

--- a/internal/application/dto/bulk_dto.go
+++ b/internal/application/dto/bulk_dto.go
@@ -135,6 +135,8 @@ type UserCSVRecord struct {
 	UserExpiration string `csv:"user_expiration" example:"31/12/2024"`
 	MacAddresses   string `csv:"mac_addresses" example:"AA:BB:CC:DD:EE:FF,11:22:33:44:55:66"`
 	AccessControl  string `csv:"access_control,omitempty" example:"192.168.1.0/24,10.0.0.0/8"`
+	IPAssignMode   string `csv:"ip_assign_mode" example:"dynamic"`
+	IPAddress      string `csv:"ip_address,omitempty" example:"10.0.0.10"`
 }
 
 // GroupCSVRecord represents a group record in CSV format - UPDATED with new fields

--- a/internal/application/dto/user_dto.go
+++ b/internal/application/dto/user_dto.go
@@ -14,6 +14,8 @@ type CreateUserRequest struct {
 	UserExpiration string   `json:"userExpiration" validate:"required,date" example:"31/12/2024"`
 	MacAddresses   []string `json:"macAddresses" validate:"required,dive,mac_address" example:"5E:CD:C9:D4:88:65"`
 	AccessControl  []string `json:"accessControl,omitempty" validate:"omitempty,dive,ipv4|cidrv4|ipv4_protocol" example:"192.168.1.0/24"`
+	IPAddress      string   `json:"ipAddress,omitempty" validate:"omitempty,ipv4" example:"10.0.0.10"`
+	IPAssignMode   string   `json:"ipAssignMode" validate:"required,oneof=dynamic static" example:"dynamic"`
 }
 
 type UpdateUserRequest struct {
@@ -22,6 +24,8 @@ type UpdateUserRequest struct {
 	MacAddresses   []string `json:"macAddresses,omitempty" validate:"omitempty,dive,mac_address" example:"5E:CD:C9:D4:88:65"`
 	AccessControl  []string `json:"accessControl,omitempty" validate:"omitempty,dive,ipv4|cidrv4|ipv4_protocol" example:"192.168.1.0/24"`
 	GroupName      string   `json:"groupName,omitempty" example:"TEST_GR"`
+	IPAddress      string   `json:"ipAddress,omitempty" validate:"omitempty,ipv4" example:"10.0.0.10"`
+	IPAssignMode   string   `json:"ipAssignMode,omitempty" validate:"omitempty,oneof=dynamic static" example:"dynamic"`
 }
 
 // Enhanced UserResponse with computed fields
@@ -36,6 +40,8 @@ type UserResponse struct {
 	DenyAccess     bool     `json:"denyAccess" example:"false"`
 	AccessControl  []string `json:"accessControl" example:"192.168.1.0/24"`
 	GroupName      string   `json:"groupName" example:"TEST_GR"`
+	IPAddress      string   `json:"ipAddress" example:"10.0.0.10"`
+	IPAssignMode   string   `json:"ipAssignMode" example:"dynamic"`
 
 	// NEW: Computed fields for enhanced filtering
 	IsEnabled    bool `json:"isEnabled" example:"true"`         // Inverse of DenyAccess
@@ -167,6 +173,9 @@ func (r CreateUserRequest) GetValidationErrors() map[string]string {
 		"MacAddresses.mac_address":   "MAC address must be in format XX:XX:XX:XX:XX:XX, XX-XX-XX-XX-XX-XX, or XXXXXXXXXXXX",
 		"AccessControl.ipv4":         "Access control must be valid IPv4 address",
 		"AccessControl.cidrv4":       "Access control must be valid CIDR notation",
+		"IPAssignMode.required":      "IP assign mode is required",
+		"IPAssignMode.oneof":         "IP assign mode must be 'dynamic' or 'static'",
+		"IPAddress.ipv4":             "IP address must be a valid IPv4 address",
 	}
 }
 
@@ -177,6 +186,8 @@ func (r UpdateUserRequest) GetValidationErrors() map[string]string {
 		"MacAddresses.mac_address": "MAC address must be in format XX:XX:XX:XX:XX:XX, XX-XX-XX-XX-XX-XX, or XXXXXXXXXXXX",
 		"AccessControl.ipv4":       "Access control must be valid IPv4 address",
 		"AccessControl.cidrv4":     "Access control must be valid CIDR notation",
+		"IPAssignMode.oneof":       "IP assign mode must be 'dynamic' or 'static'",
+		"IPAddress.ipv4":           "IP address must be a valid IPv4 address",
 	}
 }
 

--- a/internal/application/handlers/user_handler.go
+++ b/internal/application/handlers/user_handler.go
@@ -75,6 +75,8 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 		MacAddresses:   req.MacAddresses,
 		GroupName:      req.GroupName,
 		AccessControl:  req.AccessControl,
+		IPAddress:      req.IPAddress,
+		IPAssignMode:   req.IPAssignMode,
 	}
 
 	logger.Log.WithField("username", user.Username).
@@ -185,6 +187,8 @@ func (h *UserHandler) UpdateUser(c *gin.Context) {
 		MacAddresses:   req.MacAddresses,
 		AccessControl:  req.AccessControl,
 		GroupName:      req.GroupName,
+		IPAddress:      req.IPAddress,
+		IPAssignMode:   req.IPAssignMode,
 	}
 
 	if req.DenyAccess != nil {

--- a/internal/domain/entities/user.go
+++ b/internal/domain/entities/user.go
@@ -14,6 +14,8 @@ type User struct {
 	Role           string   `json:"role"`
 	DenyAccess     string   `json:"denyAccess"`
 	AccessControl  []string `json:"accessControl"`
+	IPAddress      string   `json:"ipAddress"`
+	IPAssignMode   string   `json:"ipAssignMode"`
 }
 
 type UserFilter struct {
@@ -83,6 +85,12 @@ const (
 	AuthMethodLDAP  = "ldap"
 )
 
+// IP assignment modes
+const (
+	IPAssignModeDynamic = "dynamic"
+	IPAssignModeStatic  = "static"
+)
+
 // Methods
 func (u *User) IsAdmin() bool {
 	return u.Role == UserRoleAdmin
@@ -130,12 +138,13 @@ func (u *User) SetMFA(enabled bool) {
 
 func NewUser(username, email, authMethod, groupName string) *User {
 	return &User{
-		Username:   username,
-		Email:      email,
-		AuthMethod: authMethod,
-		GroupName:  groupName,
-		Role:       UserRoleUser,
-		DenyAccess: "false",
-		MFA:        "true",
+		Username:     username,
+		Email:        email,
+		AuthMethod:   authMethod,
+		GroupName:    groupName,
+		Role:         UserRoleUser,
+		DenyAccess:   "false",
+		MFA:          "true",
+		IPAssignMode: IPAssignModeDynamic,
 	}
 }

--- a/internal/domain/usecases/user_usecase_impl.go
+++ b/internal/domain/usecases/user_usecase_impl.go
@@ -757,7 +757,8 @@ func (u *userUsecaseImpl) assignDynamicIP(ctx context.Context, groupName string)
 
 	var subnets []*net.IPNet
 	for _, s := range group.GroupSubnet {
-		_, cidr, err := net.ParseCIDR(s)
+		subnet := strings.TrimSpace(s)
+		_, cidr, err := net.ParseCIDR(subnet)
 		if err == nil {
 			subnets = append(subnets, cidr)
 		}
@@ -768,7 +769,7 @@ func (u *userUsecaseImpl) assignDynamicIP(ctx context.Context, groupName string)
 
 	var ranges []ipRange
 	for _, r := range group.GroupRange {
-		if pr, err := parseIPRange(r); err == nil {
+		if pr, err := parseIPRange(strings.TrimSpace(r)); err == nil {
 			ranges = append(ranges, pr)
 		}
 	}
@@ -815,7 +816,8 @@ func (u *userUsecaseImpl) validateStaticIP(ctx context.Context, groupName, ipStr
 
 	var inSubnet bool
 	for _, s := range group.GroupSubnet {
-		_, cidr, err := net.ParseCIDR(s)
+		subnet := strings.TrimSpace(s)
+		_, cidr, err := net.ParseCIDR(subnet)
 		if err == nil && cidr.Contains(ip) {
 			inSubnet = true
 			break
@@ -826,7 +828,7 @@ func (u *userUsecaseImpl) validateStaticIP(ctx context.Context, groupName, ipStr
 	}
 
 	for _, r := range group.GroupRange {
-		pr, err := parseIPRange(r)
+		pr, err := parseIPRange(strings.TrimSpace(r))
 		if err == nil && ipInRange(ip, pr) {
 			return fmt.Errorf("ip within restricted range")
 		}

--- a/internal/infrastructure/xmlrpc/user_client.go
+++ b/internal/infrastructure/xmlrpc/user_client.go
@@ -308,14 +308,11 @@ func (c *UserClient) makeCreateUserRequest(user *entities.User) string {
 	if user.GroupName != "" {
 		buf.WriteString(`<member><name>conn_group</name><value><string>` + c.xmlEscape(user.GroupName) + `</string></value></member>`)
 	}
-	if user.IPAddress != "" {
+	if user.IPAssignMode == entities.IPAssignModeStatic && user.IPAddress != "" {
 		buf.WriteString(`<member><name>prop_static_ip</name><value><string>` + c.xmlEscape(user.IPAddress) + `</string></value></member>`)
 	}
 	if user.UserExpiration != "" {
 		buf.WriteString(`<member><name>user_expiration</name><value><string>` + c.xmlEscape(user.UserExpiration) + `</string></value></member>`)
-	}
-	if user.IPAddress != "" {
-		buf.WriteString(`<member><name>prop_static_ip</name><value><string>` + c.xmlEscape(user.IPAddress) + `</string></value></member>`)
 	}
 
 	// MAC addresses
@@ -433,7 +430,7 @@ func (c *UserClient) makeUserPropDelRequest(user *entities.User) string {
 		accessName := fmt.Sprintf("access_to.%d", i)
 		buf.WriteString(`<value><string>` + c.xmlEscape(accessName) + `</string></value>`)
 	}
-	if user.IPAddress != "" || user.IPAssignMode != "" {
+	if user.IPAssignMode == entities.IPAssignModeStatic || user.IPAddress != "" {
 		buf.WriteString(`<value><string>prop_static_ip</string></value>`)
 	}
 	buf.WriteString(`</data></array></value></param>`)

--- a/internal/infrastructure/xmlrpc/user_client.go
+++ b/internal/infrastructure/xmlrpc/user_client.go
@@ -308,8 +308,14 @@ func (c *UserClient) makeCreateUserRequest(user *entities.User) string {
 	if user.GroupName != "" {
 		buf.WriteString(`<member><name>conn_group</name><value><string>` + c.xmlEscape(user.GroupName) + `</string></value></member>`)
 	}
+	if user.IPAddress != "" {
+		buf.WriteString(`<member><name>prop_static_ip</name><value><string>` + c.xmlEscape(user.IPAddress) + `</string></value></member>`)
+	}
 	if user.UserExpiration != "" {
 		buf.WriteString(`<member><name>user_expiration</name><value><string>` + c.xmlEscape(user.UserExpiration) + `</string></value></member>`)
+	}
+	if user.IPAddress != "" {
+		buf.WriteString(`<member><name>prop_static_ip</name><value><string>` + c.xmlEscape(user.IPAddress) + `</string></value></member>`)
 	}
 
 	// MAC addresses
@@ -426,6 +432,9 @@ func (c *UserClient) makeUserPropDelRequest(user *entities.User) string {
 	for i, _ := range user.AccessControl {
 		accessName := fmt.Sprintf("access_to.%d", i)
 		buf.WriteString(`<value><string>` + c.xmlEscape(accessName) + `</string></value>`)
+	}
+	if user.IPAddress != "" || user.IPAssignMode != "" {
+		buf.WriteString(`<value><string>prop_static_ip</string></value>`)
 	}
 	buf.WriteString(`</data></array></value></param>`)
 	buf.WriteString(`</params></methodCall>`)
@@ -579,6 +588,8 @@ func (c *UserClient) parseUserResponse(username string, body []byte) (*entities.
 			user.Email = member.Value
 		case member.Name == "user_expiration":
 			user.UserExpiration = member.Value
+		case member.Name == "prop_static_ip":
+			user.IPAddress = member.Value
 		case member.Name == "prop_superuser":
 			if member.Value == "true" {
 				user.Role = entities.UserRoleAdmin
@@ -652,6 +663,8 @@ func (c *UserClient) parseAllUsersResponse(body []byte) ([]*entities.User, error
 				user.Email = data.Value
 			case data.Name == "user_expiration":
 				user.UserExpiration = data.Value
+			case data.Name == "prop_static_ip":
+				user.IPAddress = data.Value
 			case data.Name == "prop_superuser":
 				if data.Value == "true" {
 					user.Role = entities.UserRoleAdmin


### PR DESCRIPTION
## Summary
- introduce `IPAddress` and `IPAssignMode` fields for users
- allow API to set or auto assign IP addresses
- handle IP addressing in user use case with validation
- send/read static IP from XML-RPC client
- document new fields in Swagger

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6853bf187078832cabcc47372bbafda6