### PR TITLE
Standardize API error responses

### DIFF
--- a/internal/application/dto/swagger_types.go
+++ b/internal/application/dto/swagger_types.go
@@ -17,6 +17,7 @@ type ErrorResponse struct {
 		Code    string `json:"code" example:"BAD_REQUEST"`
 		Message string `json:"message" example:"Invalid request format"`
 		Status  int    `json:"status" example:"400"`
+		Details string `json:"details,omitempty" example:"validation failed"`
 	} `json:"error"`
 }
 

--- a/internal/application/handlers/response_helpers.go
+++ b/internal/application/handlers/response_helpers.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"govpn/pkg/errors"
 	nethttp "net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
 )
 
 // Common response helper functions for all handlers
@@ -28,22 +30,62 @@ func RespondWithMessage(c *gin.Context, status int, message string) {
 }
 
 func RespondWithError(c *gin.Context, err *errors.AppError) {
-	c.JSON(err.Status, gin.H{
-		"error": gin.H{
-			"code":    err.Code,
-			"message": err.Message,
-			"status":  err.Status,
-		},
-	})
+	errorBody := gin.H{
+		"code":    err.Code,
+		"message": err.Message,
+		"status":  err.Status,
+	}
+	if err.Details != "" {
+		errorBody["details"] = err.Details
+	}
+
+	c.JSON(err.Status, gin.H{"error": errorBody})
 }
 
 func RespondWithValidationError(c *gin.Context, err error) {
+	fields := make(map[string]string)
+	if validationErrors, ok := err.(validator.ValidationErrors); ok {
+		for _, validationError := range validationErrors {
+			field := strings.ToLower(validationError.Field())
+			tag := validationError.Tag()
+
+			switch tag {
+			case "required":
+				fields[field] = field + " is required"
+			case "email":
+				fields[field] = field + " must be a valid email address"
+			case "min":
+				fields[field] = field + " is too short"
+			case "max":
+				fields[field] = field + " is too long"
+			case "username":
+				fields[field] = field + " can only contain lowercase letters, numbers, dots and underscores"
+			case "date":
+				fields[field] = field + " must be a future date in format DD/MM/YYYY"
+			case "hex16":
+				fields[field] = field + " must be 16 hexadecimal characters"
+			case "oneof":
+				fields[field] = field + " has invalid value"
+			case "ipv4":
+				fields[field] = field + " must be a valid IPv4 address"
+			case "cidrv4":
+				fields[field] = field + " must be valid CIDR notation"
+			case "ipv4_protocol":
+				fields[field] = field + " must be valid IP:protocol format"
+			default:
+				fields[field] = field + " is invalid"
+			}
+		}
+	} else {
+		fields["general"] = err.Error()
+	}
+
 	c.JSON(nethttp.StatusBadRequest, gin.H{
 		"error": gin.H{
 			"code":    "VALIDATION_ERROR",
 			"message": "Validation failed",
 			"status":  nethttp.StatusBadRequest,
-			"details": err.Error(),
+			"fields":  fields,
 		},
 	})
 }


### PR DESCRIPTION
## Summary
- include `details` field when returning errors
- return structured validation errors
- document optional `details` field in swagger types

## Testing
- `go vet ./...` *(fails: proxy.golang.org access blocked)*
- `go test ./...` *(fails: proxy.golang.org access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685424126e2c832cb847de81c5cc3f51